### PR TITLE
Remove references to files (deprecated) in get_serializer() arguments…

### DIFF
--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -1064,17 +1064,14 @@ class PlaceListView (CachedResourceMixin, LocatedResourceMixin, OwnedResourceMix
 
         return queryset
 
-    def get_serializer(self, instance=None, data=None,
-                       files=None, many=False, partial=False):
+    def get_serializer(self, instance=None, data=None, many=False, partial=False):
         """
         Override GenericAPIView.get_serializer to pass in allow_add_remove
         """
         serializer_class = self.get_serializer_class()
         context = self.get_serializer_context()
         kwargs = {'allow_add_remove': True} if many else {}
-        return serializer_class(instance, data=data, files=files,
-                                many=many, partial=partial, context=context,
-                                **kwargs)
+        return serializer_class(instance, data=data, many=many, partial=partial, context=context, **kwargs)
 
     def trigger_webhooks(self, webhooks, obj):
         """
@@ -1264,17 +1261,14 @@ class SubmissionListView (CachedResourceMixin, OwnedResourceMixin, FilteredResou
                 'submitter')\
             .prefetch_related('attachments', 'submitter__social_auth', 'submitter___groups')
 
-    def get_serializer(self, instance=None, data=None,
-                       files=None, many=False, partial=False):
+    def get_serializer(self, instance=None, data=None, many=False, partial=False):
         """
         Override GenericAPIView.get_serializer to pass in allow_add_remove
         """
         serializer_class = self.get_serializer_class()
         context = self.get_serializer_context()
         kwargs = {'allow_add_remove': True} if many else {}
-        return serializer_class(instance, data=data, files=files,
-                                many=many, partial=partial, context=context,
-                                **kwargs)
+        return serializer_class(instance, data=data, many=many, partial=partial, context=context, **kwargs)
 
 
 class DataSetSubmissionListView (CachedResourceMixin, ProtectedOwnedResourceMixin, FilteredResourceMixin, generics.ListAPIView):
@@ -1798,15 +1792,13 @@ class ClientAuthListView (OwnedResourceMixin, generics.ListCreateAPIView):
         dataset = self.get_dataset()
         return qs.filter(dataset=dataset)
 
-    def get_serializer(self, instance=None, data=None,
-                       files=None, many=False, partial=False):
+    def get_serializer(self, instance=None, data=None, many=False, partial=False):
         if isinstance(data, dict):
             dataset = self.get_dataset()
             data = data.copy()
             data['dataset'] = dataset.id
         return super(ClientAuthListView, self).get_serializer(
-            instance=instance, data=data, files=files, many=many,
-            partial=partial)
+            instance=instance, data=data, many=many, partial=partial)
 
 
 class ApiKeyListView (ClientAuthListView):


### PR DESCRIPTION
…. For issue #47.

Delete references to `files` in `get_serializer()` in `sa_api_v2/views/base_views.py`. Simply remove the argument since it is deprecated and now included in `request.data`.
