### PR TITLE
fix facebook social logins

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -213,11 +213,11 @@ AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
 
-SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'bio']
+SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture']
 SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url']
 
 # Explicitly request the following extra things from facebook
-SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,bio'}
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name'}
 
 SOCIAL_AUTH_LOGIN_ERROR_URL = 'remote-social-login-error'
 

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -213,11 +213,11 @@ AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
 
-SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture']
+SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'about']
 SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url']
 
 # Explicitly request the following extra things from facebook
-SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name'}
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,about'}
 
 SOCIAL_AUTH_LOGIN_ERROR_URL = 'remote-social-login-error'
 

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -376,7 +376,7 @@ class FacebookUserDataStrategy (object):
         return user_info['name']
 
     def extract_bio(self, user_info):
-        return ''
+        return user_info['about']
 
 
 class ShareaboutsUserDataStrategy (object):

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -376,7 +376,7 @@ class FacebookUserDataStrategy (object):
         return user_info['name']
 
     def extract_bio(self, user_info):
-        return user_info['bio']
+        return ''
 
 
 class ShareaboutsUserDataStrategy (object):


### PR DESCRIPTION
For facebook open graph api versions >= 2.8, apparently the bio field is no longer a valid request parameter. The api reports:

```
(#12) bio field is deprecated for versions v2.8 and higher
```

Requests made with the bio field included will return a 400 error. After removing the bio field from our requests, Facebook logins are working again.