### PR TITLE
Add google login option

### DIFF
--- a/src/project/local_settings.py
+++ b/src/project/local_settings.py
@@ -66,6 +66,11 @@ SOCIAL_AUTH_FACEBOOK_KEY = os.environ.get('SOCIAL_AUTH_FACEBOOK_KEY',
 SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET',
                                              'NO_SOCIAL_AUTH_FACEBOOK_SECRET')
 
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY',
+                                               'NO_SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = os.environ.get('SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET',
+                                                  'NO_SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')
+
 # Django will use django.core.files.storage.FileSystemStorage by default.
 # Uncomment the following lines if you want to use S3 storage instead.
 #

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -206,6 +206,7 @@ AUTHENTICATION_BACKENDS = (
     # for list of available backends.
     'social.backends.twitter.TwitterOAuth',
     'social.backends.facebook.FacebookOAuth2',
+    'social.backends.google.GoogleOAuth2',
     'sa_api_v2.auth_backends.CachedModelBackend',
 )
 
@@ -215,6 +216,7 @@ SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
 
 SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'bio']
 SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url']
+SOCIAL_AUTH_GOOGLE_OAUTH2_EXTRA_DATA = ['name', 'image', 'aboutMe']
 
 # Explicitly request the following extra things from facebook
 SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,bio'}

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -379,6 +379,18 @@ class FacebookUserDataStrategy (object):
         return user_info['bio']
 
 
+class GoogleUserDataStrategy (object):
+    def extract_avatar_url(self, user_info):
+       url = user_info['image']['url']
+       return url
+
+    def extract_full_name(self, user_info):
+        name = user_info['name']['givenName'] + ' ' + user_info['name']['familyName']
+        return name
+
+    def extract_bio(self, user_info):
+        return user_info["aboutMe"]
+
 class ShareaboutsUserDataStrategy (object):
     """
     This strategy exists so that we can add avatars and full names to users
@@ -502,6 +514,7 @@ class BaseUserSerializer (serializers.ModelSerializer):
     strategies = {
         'twitter': TwitterUserDataStrategy(),
         'facebook': FacebookUserDataStrategy(),
+        'google-oauth2': GoogleUserDataStrategy(),
         'shareabouts': ShareaboutsUserDataStrategy()
     }
     default_strategy = DefaultUserDataStrategy()


### PR DESCRIPTION
Add Google to our list of supported social auth login options.

I tested this a bit via ngrok, and it seems to work well. Using google requires a process similar to the facebook app creation process, where we have to register domains. We also have to explicitly enable the Google+ API for logins to work.

Once this is merged and deployed I'll add a button on the frontend for Google logins.