### PR TITLE
Allow cross-origin OPTIONS requests to set Access-Control-Allow-Origin header

### DIFF
--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -428,7 +428,7 @@ class CorsEnabledMixin (object):
     """
     A view that puts Access-Control headers on the response.
     """
-    always_allow_options = False
+    always_allow_options = True
     SAFE_CORS_METHODS = ('GET', 'HEAD', 'TRACE')
 
     def finalize_response(self, request, response, *args, **kwargs):


### PR DESCRIPTION
To support cross-origin ajax requests with credentials, we have to allow the api to return an Access-Control-Allow-Origin header with the requesting domain set. The more permissive * value for this header won't work. It's a violation of CORS policy to make a cross-origin request with credentials with the Access-Control-Allow-Origin set to the * wildcard.

This PR will make https://github.com/mapseed/platform/pull/807 possible, which moves to the client the proxy-server functionality that attached the appropriate session cookie.