### PR TITLE
feat(localSettings) add email notification settings

### DIFF
--- a/src/project/local_settings.py
+++ b/src/project/local_settings.py
@@ -85,13 +85,13 @@ ATTACHMENT_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 # STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 
 # email notification service:
-if all(k in os.environ for k in ['EMAIL_ADDRESS', 'EMAIL_HOST', 'EMAIL_PORT',
-                                 'EMAIL_USERNAME', 'EMAIL_PASSWORD', 'EMAIL_USE_TLS',
-                                 'EMAIL_NOTIFICATIONS_BCC']):
+if all(k in os.environ for k in ['EMAIL_HOST', 'EMAIL_PORT',
+                                 'EMAIL_HOST_USER', 'EMAIL_HOST_PASSWORD',
+                                 'EMAIL_USE_TLS']):
     EMAIL_HOST = os.environ['EMAIL_HOST']
     EMAIL_PORT = os.environ['EMAIL_PORT']
-    EMAIL_HOST_USER = os.environ['EMAIL_USERNAME']
-    EMAIL_HOST_PASSWORD = os.environ['EMAIL_PASSWORD']
+    EMAIL_HOST_USER = os.environ['EMAIL_HOST_USER']
+    EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
     EMAIL_USE_TLS = (os.environ['EMAIL_USE_TLS'].lower() in
                      ('true', 'on', 't', 'yes'))
     EMAIL_DEBUG = (os.environ.get('EMAIL_DEBUG').lower() in

--- a/src/project/local_settings.py
+++ b/src/project/local_settings.py
@@ -84,6 +84,21 @@ ATTACHMENT_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 # ATTACHMENT_STORAGE = DEFAULT_FILE_STORAGE
 # STATICFILES_STORAGE = DEFAULT_FILE_STORAGE
 
+# email notification service:
+if all(k in os.environ for k in ['EMAIL_ADDRESS', 'EMAIL_HOST', 'EMAIL_PORT',
+                                 'EMAIL_USERNAME', 'EMAIL_PASSWORD', 'EMAIL_USE_TLS',
+                                 'EMAIL_NOTIFICATIONS_BCC']):
+    EMAIL_HOST = os.environ['EMAIL_HOST']
+    EMAIL_PORT = os.environ['EMAIL_PORT']
+    EMAIL_HOST_USER = os.environ['EMAIL_USERNAME']
+    EMAIL_HOST_PASSWORD = os.environ['EMAIL_PASSWORD']
+    EMAIL_USE_TLS = os.environ['EMAIL_USE_TLS']
+    EMAIL_DEBUG = (os.environ.get('EMAIL_DEBUG').lower() in
+                   ('true', 'on', 't', 'yes'))
+    EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' \
+                    if not EMAIL_DEBUG else \
+                    'django.core.mail.backends.console.EmailBackend'
+
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID',
                                    'NO_AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY',

--- a/src/project/local_settings.py
+++ b/src/project/local_settings.py
@@ -92,7 +92,8 @@ if all(k in os.environ for k in ['EMAIL_ADDRESS', 'EMAIL_HOST', 'EMAIL_PORT',
     EMAIL_PORT = os.environ['EMAIL_PORT']
     EMAIL_HOST_USER = os.environ['EMAIL_USERNAME']
     EMAIL_HOST_PASSWORD = os.environ['EMAIL_PASSWORD']
-    EMAIL_USE_TLS = os.environ['EMAIL_USE_TLS']
+    EMAIL_USE_TLS = (os.environ['EMAIL_USE_TLS'].lower() in
+                     ('true', 'on', 't', 'yes'))
     EMAIL_DEBUG = (os.environ.get('EMAIL_DEBUG').lower() in
                    ('true', 'on', 't', 'yes'))
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' \

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -375,11 +375,6 @@ if 'DEBUG' in environ:
     TEMPLATE_DEBUG = DEBUG
     SHOW_DEBUG_TOOLBAR = DEBUG
 
-EMAIL_DEBUG = ((environ.get('EMAIL_DEBUG') or '').lower() in
-                   ('true', 'on', 't', 'yes'))
-EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend' \
-                if not EMAIL_DEBUG else \
-                'django.core.mail.backends.console.EmailBackend'
 
 # Look for the following redis environment variables, in order
 for REDIS_URL_ENVVAR in ('REDIS_URL', 'OPENREDIS_URL'):


### PR DESCRIPTION
This PR adds some minor changes to our Django settings, described below:

 * There are a few email settings that we are missing, as documented here: https://docs.djangoproject.com/en/1.7/ref/settings/#email-host So this PR adds those missing variables.

 * The `.env` in our deployment scripts contains the email settings, which gets parsed in `local_settings.py`, not `settings.py`, so this PR fixes that. If interested, you can see that the `.env` config gets parsed here: https://github.com/mapseed/api/compare/place-email...luke/place-email?expand=1#diff-96acbce0311b17ac0c52c0bd5dadefaaL30 
