### PR TITLE
Fix SSL sign-ins

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -47,6 +47,8 @@ ROOT_REDIRECT_TO = 'api-root'
 # processed by Django as HTTPS requests
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+USE_X_FORWARDED_HOST = True
+
 ###############################################################################
 #
 # Time Zones

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -43,6 +43,10 @@ API_CACHE_TIMEOUT = 3600  # an hour
 # Where should the user be redirected to when they visit the root of the site?
 ROOT_REDIRECT_TO = 'api-root'
 
+# Ensure forwards from the proxy that originate as HTTPS are passed through and
+# processed by Django as HTTPS requests
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 ###############################################################################
 #
 # Time Zones


### PR DESCRIPTION
Addresses: https://github.com/mapseed/platform/issues/394

**NOTE:** This PR works in conjunction with https://github.com/modulitos/docker-shareabouts/pull/11.

This PR adds two pieces of configuration to `settings.py`:

```
SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
```
tells Django to assume that traffic forwarded from the reverse proxy containing the `X-Forwarded-Proto` header with a value of `https` is traffic that originated from the client over https. This information is used internally when processing responses with the `HttpResponseRedirect` class (see [here](https://github.com/mapseed/api/blob/master/src/sa_api_v2/views/base_views.py#L2058-L2063)).

Previously, traffic from the proxy appeared to Django as non-secure, which caused Django to set the `Location` response header with an http url. This url was used by the browser and resulted in a mixed content error--this was the cause of the SSL sign in bug.

```
USE_X_FORWARDED_HOST = True
```
tells Django to use the value of the `X-Forwarded-Host` header passed from the reverse proxy when constructing the `Location` header. Without this set, the `Location` header is constructed with the internal backend uri, which is meaningless to the client.