### PR TITLE
Ensure twitter avatars are fetched over https

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -221,7 +221,7 @@ SOCIAL_AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
 
 SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'about']
-SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url']
+SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url_https']
 SOCIAL_AUTH_GOOGLE_OAUTH2_EXTRA_DATA = ['name', 'image', 'aboutMe']
 
 # Explicitly request the following extra things from facebook

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -351,7 +351,10 @@ class DefaultUserDataStrategy (object):
 
 class TwitterUserDataStrategy (object):
     def extract_avatar_url(self, user_info):
-        url = user_info['profile_image_url']
+        try:
+          url = user_info['profile_image_url_https']
+        except:
+          url = user_info['profile_image_url']
 
         url_pattern = '^(?P<path>.*?)(?:_normal|_mini|_bigger|)(?P<ext>\.[^\.]*)$'
         match = re.match(url_pattern, url)

--- a/src/sa_api_v2/tests/test_serializers.py
+++ b/src/sa_api_v2/tests/test_serializers.py
@@ -145,7 +145,7 @@ class TestSocialUserSerializer (TestCase):
         self.assertIn('avatar_url', serializer.data)
 
         self.assertEqual(serializer.data['name'], 'Mjumbe Poe')
-        self.assertEqual(serializer.data['avatar_url'], 'http://a0.twimg.com/profile_images/1101892515/dreadlocked_browntwitterbird-248x270_bigger.png')
+        self.assertEqual(serializer.data['avatar_url'], 'https://si0.twimg.com/profile_images/1101892515/dreadlocked_browntwitterbird-248x270_bigger.png')
 
     def test_facebook_user_attributes(self):
         serializer = UserSerializer(self.facebook_user)


### PR DESCRIPTION
I think for this to work, once it's merged and deployed we'll have to manually update existing social auths on the api one last time.