### PR TITLE
Remove use of many=True kwarg in DataSetSerializer

### DIFF
--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -1013,8 +1013,8 @@ class DataSetSerializer (BaseDataSetSerializer, serializers.HyperlinkedModelSeri
     url = DataSetIdentityField()
     owner = UserRelatedField()
 
-    places = DataSetPlaceSetSummarySerializer(source='*', read_only=True, many=True)
-    submission_sets = DataSetSubmissionSetSummarySerializer(source='*', read_only=True, many=True)
+    places = DataSetPlaceSetSummarySerializer(source='*', read_only=True)
+    submission_sets = DataSetSubmissionSetSummarySerializer(source='*', read_only=True)
 
     load_from_url = serializers.URLField(write_only=True, required=False)
 


### PR DESCRIPTION
Addresses: #107, #109, and #110

The `many=True` argument to serializers automatically invokes use of a new DRF class called `ListSerializer` (see [here](http://www.django-rest-framework.org/topics/3.0-announcement/#the-listserializer-class) for the announcement) in DRF3.

This is an issue for our `DataSetSerializer`, which itself has two serializer fields (`DataSetPlaceSetSummarySerializer` and `DataSetSubmissionSetSummarySerializer`) that declare a `many=True` relationship. I think because the model underlying those serializers is a `DataSet`, this generates the error condition we see:
```
'DataSet' object is not iterable
```

Removing the `many=True` kwargs fixes this problem and the corresponding test passes, but I'm unclear if this is actually what we want to be doing here?