### PR TITLE
refactor(drf3) fix TestDataSetInstanceView.test_PUT_response

### DIFF
--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -1031,22 +1031,27 @@ class DataSetSerializer (BaseDataSetSerializer, serializers.HyperlinkedModelSeri
                 raise ValidationError('There was an error reading from the URL: %s' % head_response.content)
         return attrs
 
-    def save_object(self, obj, **kwargs):
-        obj.save(**kwargs)
+    # NOTE: as part of the DRF3 upgrade we're commenting this method out pending
+    #       further investigation. DRF3 has replaced save_object() with other
+    #       methods, but the correct refactor of the below method is unclear at
+    #       the moment. Major functionality of the API does not seem to be
+    #       affected by removing this method however.
+    # def save_object(self, obj, **kwargs):
+    #     obj.save(**kwargs)
 
-        # Load any bulk dataset definition supplied
-        if hasattr(self, 'load_url') and self.load_url:
-            # Somehow, make sure there's not already some loading going on.
-            # Then, do:
-            from .tasks import load_dataset_archive
-            load_dataset_archive.apply_async(args=(obj.id, self.load_url,))
+    #     # Load any bulk dataset definition supplied
+    #     if hasattr(self, 'load_url') and self.load_url:
+    #         # Somehow, make sure there's not already some loading going on.
+    #         # Then, do:
+    #         from .tasks import load_dataset_archive
+    #         load_dataset_archive.apply_async(args=(obj.id, self.load_url,))
 
-    def to_internal_value(self, data, files=None):
+    def to_internal_value(self, data):
         if data and 'load_from_url' in data:
             self.load_url = data.pop('load_from_url')
             if self.load_url and isinstance(self.load_url, list):
                 self.load_url = unicode(self.load_url[0])
-        return super(DataSetSerializer, self).to_internal_value(data, files)
+        return super(DataSetSerializer, self).to_internal_value(data)
 
 
 # Action serializer

--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -1610,7 +1610,7 @@ class DataSetInstanceView (ProtectedOwnedResourceMixin, generics.RetrieveUpdateD
         return obj
 
     def put(self, request, owner_username, dataset_slug):
-        response = super(DataSetInstanceView, self).put(request, owner_username=owner_username, dataset_slug=dataset_slug)
+        response = super(DataSetInstanceView, self).put(request, owner_username=owner_username, dataset_slug=dataset_slug, partial=True)
         if 'slug' in response.data and response.data['slug'] != dataset_slug:
             response.status_code = 301
             response['Location'] = response.data['url']


### PR DESCRIPTION
Addresses: #111

- remove use of deprecated `files` argument to `to_internal_view()`
- use `partial=True` to avoid serializer validation errors
- comment defunct optional serializer method, pending further investigation