### PR TITLE
chore(.travis.yml) use legacy ubuntu trusty for ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 before_install:
   - sudo apt-get install -y git
   - git clone https://github.com/LukeSwart/docker-shareabouts.git
-  - docker pull kartoza/postgis:9.4-2.1
+  - docker pull kartoza/postgis:9.6-2.4
   - cd docker-shareabouts/backend && mv .env.template .env && ./letsdeploy.sh && cd -
   - mv src/template.env src/.env
   - sudo apt-get install libgdal-dev python-gdal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+group: deprecated-2017Q4
 language: python
 python:
   - '2.7'


### PR DESCRIPTION
 - more here: https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch