### PR TITLE
Fix FB logins

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -211,7 +211,8 @@ AUTHENTICATION_BACKENDS = (
     # See http://django-social-auth.readthedocs.org/en/latest/configuration.html
     # for list of available backends.
     'social.backends.twitter.TwitterOAuth',
-    'social.backends.facebook.FacebookOAuth2',
+    #'social.backends.facebook.FacebookOAuth2',
+    'sa_api_v2.auth_backends.NoRedirectStateFacebookOAuth2',
     'social.backends.google.GoogleOAuth2',
     'sa_api_v2.auth_backends.CachedModelBackend',
 )

--- a/src/sa_api_v2/auth_backends.py
+++ b/src/sa_api_v2/auth_backends.py
@@ -10,5 +10,10 @@ class CachedModelBackend (ModelBackend):
             UserCache.set_instance(user, user_id=user_id)
         return user
 
+# This custom backend prevents the dynamic redirect_state query param from
+# being sent with FB OAuth requests. redirect_state interferes with upgraded
+# FB security requirements.
+# https://stackoverflow.com/questions/45307723/valid-oauth-redirect-uris-for-facebook-django-social-auth
+# https://developers.facebook.com/docs/facebook-login/security/#surfacearea
 class NoRedirectStateFacebookOAuth2(FacebookOAuth2):
     REDIRECT_STATE = False

--- a/src/sa_api_v2/auth_backends.py
+++ b/src/sa_api_v2/auth_backends.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.backends import ModelBackend
 from .cache import UserCache
+from social.backends.facebook import FacebookOAuth2
 
 class CachedModelBackend (ModelBackend):
     def get_user(self, user_id):
@@ -8,3 +9,6 @@ class CachedModelBackend (ModelBackend):
             user = super(CachedModelBackend, self).get_user(user_id)
             UserCache.set_instance(user, user_id=user_id)
         return user
+
+class NoRedirectStateFacebookOAuth2(FacebookOAuth2):
+    REDIRECT_STATE = False


### PR DESCRIPTION
Fixes: #128 

Prevent `python-social-auth` from including the dynamic `redirect_state` query param in OAuth requests to Facebook. This allows us to whitelist our domain with Facebook and fixes Facebook logins.