### PR TITLE
feat(urls.py): add a 'mapseed-places.csv' download route

### DIFF
--- a/src/sa_api_v2/urls.py
+++ b/src/sa_api_v2/urls.py
@@ -54,6 +54,12 @@ urlpatterns = patterns('sa_api_v2',
         views.PlaceListView.as_view(),
         name='place-list'),
 
+    # HACK: Adding this route so that the downloaded file has the `.csv` extension:
+    # https://github.com/mapseed/api/issues/139
+    url(r'^(?P<owner_username>[^/]+)/datasets/(?P<dataset_slug>[^/]+)/mapseed-places.csv',
+        views.PlaceListView.as_view(),
+        name='place-list'),
+
     url(r'^~/datasets$',
         views.AdminDataSetListView.as_view(),
         name='admin-dataset-list'),


### PR DESCRIPTION
Related to: https://github.com/mapseed/api/issues/139

This PR adds an endpoint that allows us to download a page of our survey data to a file with a `.csv` extension

Note that I tried to rename the downloaded file on the frontend via the `a` tag's `download` attribute, but it doesn't seem possible due to CORS:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Attributes

 It seems like the best way to do this was renaming the endpoint on the backend.