### PR TITLE
Jalmogo/fix deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 ############################################################
 
 # Set the base image to Debian
-FROM buildpack-deps:jessie
+FROM python:2.7.15-stretch
 
 # File Author / Maintainer
 MAINTAINER Luke Swart <luke@smartercleanup.org>
@@ -19,10 +19,10 @@ RUN apt-get install -y tar git curl wget dialog net-tools build-essential gettex
 RUN apt-get install -y python-dev python-distribute python-pip
 
 # Install Postgres/PostGIS dependencies:
-RUN apt-get install -y python-psycopg2 postgresql libpq-dev postgresql-9.4-postgis-2.1 postgis postgresql-9.4
+RUN apt-get install -y python-psycopg2 postgresql libpq-dev postgresql-9.6-postgis-2.3 postgis postgresql-9.6
 
 # If you want to deploy from an online host git repository, you can use the following command to clone:
-RUN git clone https://github.com/mapseed/api.git && cd api && git checkout 1.0.1 && cd -
+RUN git clone https://github.com/mapseed/api.git && cd api && git checkout 1.0.2 && cd -
 # # for local testing, cd into project root and uncomment this line:
 # ADD . api
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get install -y python-dev python-distribute python-pip
 RUN apt-get install -y python-psycopg2 postgresql libpq-dev postgresql-9.4-postgis-2.1 postgis postgresql-9.4
 
 # If you want to deploy from an online host git repository, you can use the following command to clone:
-RUN git clone https://github.com/mapseed/api.git && cd api && git checkout 0.6.10 && cd -
+RUN git clone https://github.com/mapseed/api.git && cd api && git checkout 1.0.1 && cd -
 # # for local testing, cd into project root and uncomment this line:
 # ADD . api
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 Django==1.8.12
 gevent==1.1.1
-gunicorn==19.5.0
+gunicorn==19.4.5
 newrelic==2.60.0.46
 dj-static==0.0.6
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 
 Django==1.8.12
 gevent==1.1.1
-gunicorn==19.4.5
+gunicorn==19.5
 newrelic==2.60.0.46
 dj-static==0.0.6
 
@@ -66,7 +66,7 @@ djangorestframework-jsonp>=1.0.0,<1.1
 # replace forked drf-bulk with main version
 djangorestframework-bulk==0.2
 six>=1.10.0
-markdown  # For browsable API docs
+markdown==2.6.11  # For browsable API docs
 python-dateutil==2.5
 ujson==1.35
 Pillow==3.1.1


### PR DESCRIPTION
fixes this error on the docker container:

```
root@4c92d24efc7a:/api# pip --version
Traceback (most recent call last):
  File "/usr/bin/pip", line 9, in <module>
    load_entry_point('pip==1.5.6', 'console_scripts', 'pip')()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 356, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2476, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.7/dist-packages/pkg_resources.py", line 2190, in load
    ['__name__'])
  File "/usr/lib/python2.7/dist-packages/pip/__init__.py", line 74, in <module>
    from pip.vcs import git, mercurial, subversion, bazaar  # noqa
  File "/usr/lib/python2.7/dist-packages/pip/vcs/mercurial.py", line 9, in <module>
    from pip.download import path_to_url
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 25, in <module>
    from requests.compat import IncompleteRead
ImportError: cannot import name IncompleteRead
```

Updating the python 2 version fixed this
