### PR TITLE
refactor(GroupSerializer): serialize group permissions and dataset slug

### DIFF
--- a/src/sa_api_v2/models/data_permissions.py
+++ b/src/sa_api_v2/models/data_permissions.py
@@ -59,13 +59,17 @@ class DataPermission (CloneableModelMixin, CacheClearingModel, models.Model):
         return locals()
     dataset = property(**dataset())
 
-    def abilities(self):
+    def get_abilities(self):
         abilities = []
         if self.can_create: abilities.append('create')
         if self.can_retrieve: abilities.append('retrieve')
         if self.can_update: abilities.append('update')
         if self.can_destroy: abilities.append('destroy')
 
+        return abilities
+
+    def abilities(self):
+        abilities = self.get_abilities()
         things = self.submission_set if self.submission_set.strip() not in ('', '*') else 'anything'
 
         if abilities:

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -578,8 +578,7 @@ class GroupSerializer (BaseGroupSerializer):
         ret['dataset_slug'] = obj.dataset.slug
         ret['permissions'] = [] 
 
-        permissions = obj.permissions.all()
-        for permission in permissions:
+        for permission in obj.permissions.all():
             ret['permissions'].append({
                 'abilities': permission.get_abilities(),
                 'submission_set': permission.submission_set

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -575,6 +575,16 @@ class GroupSerializer (BaseGroupSerializer):
         ret['dataset'] = six.text_type(self.fields['dataset']
                                        .to_representation(obj.dataset))
         ret['name'] = obj.name
+        ret['dataset_slug'] = obj.dataset.slug
+        ret['permissions'] = [] 
+
+        permissions = obj.permissions.all()
+        for permission in permissions:
+            ret['permissions'].append({
+                'abilities': permission.get_abilities(),
+                'submission_set': permission.submission_set
+            })
+
         return ret
 
 

--- a/src/sa_api_v2/tests/test_serializers.py
+++ b/src/sa_api_v2/tests/test_serializers.py
@@ -241,7 +241,9 @@ class TestUserSerializer (TestCase):
             [{'dataset': reverse('dataset-detail',
                                  kwargs={'dataset_slug': 'ds1',
                                          'owner_username': 'my_owning_user'}),
-              'name': 'special users'}])
+              'name': 'special users',
+              'dataset_slug': 'ds1',
+              'permissions': []}])
 
 
 class TestPlaceSerializer (TestCase):


### PR DESCRIPTION
This PR serializes permissions for each dataset group returned along with the `User` serialization. Group permissions are serialized as an array in the following format:
```
[
  {
    abilities: ["create", "retrieve", "update", "destroy"],
    submission_set: "*"
  }
]
```
where each object in the array represents one set of permissions.

We also serialize the `dataset_slug` of each group's parent dataset.