### PR TITLE
feat(TagSerializer): return children id's

### DIFF
--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -1124,7 +1124,7 @@ class TagSerializer (serializers.ModelSerializer):
 
     class Meta:
         model = models.Tag
-        fields = ['id', 'url', 'name', 'parent', 'color', 'is_enabled']
+        fields = ['id', 'url', 'name', 'parent', 'color', 'is_enabled', 'children']
 
 
 class PlaceTagSerializer (serializers.ModelSerializer):


### PR DESCRIPTION
This allows our tag endpoints to return a `children` attribute, containing an array of tag id's.
