### PR TITLE
fix(PlaceInstanceView): don't update the submitter on PUT requests

### DIFF
--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -760,10 +760,8 @@ class PlaceInstanceView (Sanitizer, CachedResourceMixin, LocatedResourceMixin, O
                 user = serializer.instance.submitter
             if 'submitter' in serializer.validated_data:
                 user = serializer.validated_data['submitter']
-            self.object = serializer.save(
-                submitter=user if user is not None and user.is_authenticated() else None,
-                **save_kwargs
-            )
+                print('user', user)
+            self.object = serializer.save(**save_kwargs)
             return Response(serializer.data, status=success_status_code)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sa_api_v2/views/base_views.py
+++ b/src/sa_api_v2/views/base_views.py
@@ -760,7 +760,6 @@ class PlaceInstanceView (Sanitizer, CachedResourceMixin, LocatedResourceMixin, O
                 user = serializer.instance.submitter
             if 'submitter' in serializer.validated_data:
                 user = serializer.validated_data['submitter']
-                print('user', user)
             self.object = serializer.save(**save_kwargs)
             return Response(serializer.data, status=success_status_code)
 


### PR DESCRIPTION
Closes: https://github.com/jalMogo/mgmt/issues/227

This PR prevents the API from updating the `submitter` of a place when making a `PUT` request. There is no use case I can think of for an editor updating the original submitter of a Place.