### PR TITLE
refactor(dataPermissions): serialize group can_access_protected permissions

### DIFF
--- a/src/sa_api_v2/models/data_permissions.py
+++ b/src/sa_api_v2/models/data_permissions.py
@@ -70,6 +70,7 @@ class DataPermission (CloneableModelMixin, CacheClearingModel, models.Model):
         if self.can_retrieve: abilities.append('retrieve')
         if self.can_update: abilities.append('update')
         if self.can_destroy: abilities.append('destroy')
+        if self.can_access_protected: abilities.append('can_access_protected')
 
         return abilities
 


### PR DESCRIPTION
This PR adds the `can_access_protected` permission to the group permission serializer.